### PR TITLE
Add spherical geometry to convective_grad

### DIFF
--- a/source/amrex_astro_util.H
+++ b/source/amrex_astro_util.H
@@ -186,7 +186,7 @@ get_pres_index(const std::vector<std::string>& var_names_pf) {
     auto idx = std::find(var_names_pf.cbegin(), var_names_pf.cend(), "pressure");
     if (idx == var_names_pf.cend()) {
         // for MAESTROeX, we'll default to "p0"
-        idx = std::find(var_names_pf.cbegin(), var_names_pf.cend(), "p0");
+        idx = std::find(var_names_pf.cbegin(), var_names_pf.cend(), "p0pluspi");
         if (idx == var_names_pf.cend()) {
             amrex::Error("Error: could not find the pressure component");
         }

--- a/source/convective_grad/_parameters
+++ b/source/convective_grad/_parameters
@@ -5,4 +5,4 @@ small_dens     real         -1.e200
 
 plotfile       string       ""
 
-spherical 	   bool         0
+spherical 	   bool         false

--- a/source/convective_grad/_parameters
+++ b/source/convective_grad/_parameters
@@ -4,3 +4,5 @@ small_temp     real         -1.e200
 small_dens     real         -1.e200
 
 plotfile       string       ""
+
+spherical 	   bool         0

--- a/source/convective_grad/main.cpp
+++ b/source/convective_grad/main.cpp
@@ -225,9 +225,9 @@ void main_main()
                 // calc position if spherical
                 Real xpos, ypos, zpos;
                 if (diag_rp::spherical){
-                    xpos = probLo[0] + dx[0] * i - center[0];
-                    ypos = probLo[1] + dx[1] * j - center[1];
-                    zpos = probLo[2] + dx[2] * k - center[2];
+                    xpos = probLo[0] + dx[0] * (Real(i) + 0.5_rt) - center[0];
+                    ypos = probLo[1] + dx[1] * (Real(j) + 0.5_rt) - center[1];
+                    zpos = probLo[2] + dx[2] * (Real(k) + 0.5_rt) - center[2];
                 }
 
                 // first dlog T / dlog P actual -- we assume that the last

--- a/source/convective_grad/main.cpp
+++ b/source/convective_grad/main.cpp
@@ -90,6 +90,16 @@ void main_main()
         }
     }
 
+    // get center if spherical
+    if (diag_rp::spherical){
+
+        Array<Real, AMREX_SPACEDIM> center;
+        auto const probLo = pf.probLo();
+        auto const probHi = pf.probHi();
+        for (idim = 0; idim < AMREX_SPACEDIM; ++idim){
+            center[idim] = (probHi[idim] - probLo[idim]) / 2;
+        }
+    }
     // we need both T and P constructed with ghost cells
 
     Vector<MultiFab> gmf(nlevs);
@@ -211,34 +221,83 @@ void main_main()
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
 
+                Real xpos = probLo[0] + dx[0] * i - center[0];
+                Real ypos = probLo[1] + dx[1] * j - center[1];
+                Real zpos = probLo[2] + dx[2] * k - center[2];
+
                 // first dlog T / dlog P actual -- we assume that the last
                 // dimension is the vertical (plane-parallel)
 
-                if (ndims == 1) {
-                    // x is the vertical
-                    Real dp = P(i+1,j,k) - P(i-1,j,k);
-                    if (dp != 0.0) {
-                        ga(i,j,k,0) = (T(i+1,j,k) - T(i-1,j,k)) / dp * (P(i,j,k) / T(i,j,k));
-                    } else {
-                        ga(i,j,k,0) = 0.0;
-                    }
+                if (!diag_rp::spherical) {
 
-                } else if (ndims == 2) {
-                    // y is the vertical
-                    Real dp = P(i,j+1,k) - P(i,j-1,k);
-                    if (dp != 0.0) {
-                        ga(i,j,k,0) = (T(i,j+1,k) - T(i,j-1,k)) / dp * (P(i,j,k) / T(i,j,k));
-                    } else {
-                        ga(i,j,k,0) = 0.0;
-                    }
+                    if (ndims == 1) {
+                        // x is the vertical
+                        Real dp = P(i+1,j,k) - P(i-1,j,k);
+                        if (dp != 0.0) {
+                            ga(i,j,k,0) = (T(i+1,j,k) - T(i-1,j,k)) / dp * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
 
+                    } else if (ndims == 2) {
+                        // y is the vertical
+                        Real dp = P(i,j+1,k) - P(i,j-1,k);
+                        if (dp != 0.0) {
+                            ga(i,j,k,0) = (T(i,j+1,k) - T(i,j-1,k)) / dp * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
+
+                    } else {
+                        // z is the vertical
+                        Real dp = P(i,j,k+1) - P(i,j,k-1);
+                        if (dp != 0.0) {
+                            ga(i,j,k,0) = (T(i,j,k+1) - T(i,j,k-1)) / dp * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
+                    }
                 } else {
-                    // z is the vertical
-                    Real dp = P(i,j,k+1) - P(i,j,k-1);
-                    if (dp != 0.0) {
-                        ga(i,j,k,0) = (T(i,j,k+1) - T(i,j,k-1)) / dp * (P(i,j,k) / T(i,j,k));
+                    //spherical case
+                    if (ndims == 1) {
+                        // x is the vertical
+                        // same as plane parallel
+                        Real dp = P(i+1,j,k) - P(i-1,j,k);
+                        if (dp != 0.0) {
+                            ga(i,j,k,0) = (T(i+1,j,k) - T(i-1,j,k)) / dp * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
+
+                    } else if (ndims == 2) {
+                        // r is from x and y 
+                        Real dp = (xpos / dx[0]) * (P(i+1,j,k) - P(i-1,j,k))
+                                + (ypos / dx[1]) * (P(i,j+1,k) - P(i,j-1,k));
+
+                        if (dp != 0.0) {
+                            Real dT = (xpos / dx[0]) * (T(i+1,j,k) - T(i-1,j,k))
+                                    + (ypos / dx[1]) * (T(i,j+1,k) - T(i,j-1,k));
+
+                            ga(i,j,k,0) = (dT / dp) * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
+
                     } else {
-                        ga(i,j,k,0) = 0.0;
+                       // r is from x, y, and z
+                        Real dp = (xpos / dx[0]) * (P(i+1,j,k) - P(i-1,j,k))
+                                + (ypos / dx[1]) * (P(i,j+1,k) - P(i,j-1,k))
+                                + (zpos / dx[2]) * (P(i,j,k+1) - P(i,j,k+1)); 
+
+                        if (dp != 0.0) {
+                            Real dT = (xpos / dx[0]) * (T(i+1,j,k) - T(i-1,j,k))
+                                    + (ypos / dx[1]) * (T(i,j+1,k) - T(i,j-1,k))
+                                    + (zpos / dx[2]) * (T(i,j,k+1) - T(i,j,k+1)); 
+
+                            ga(i,j,k,0) = (dT / dp) * (P(i,j,k) / T(i,j,k));
+                        } else {
+                            ga(i,j,k,0) = 0.0;
+                        }
                     }
                 }
 
@@ -268,58 +327,175 @@ void main_main()
                 Real lnPalt_plus{0.0};  // pressure with "above" species
                 Real lnPalt_minus{0.0};  // pressure with "below" species
 
-                if (ndims == 1) {
-                    // x is the vertical
+                if (! diag_rp::spherical){
 
-                    lnP_plus = std::log(P(i+1,j,k));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i+1,j,k,n);
+                    if (ndims == 1) {
+                        // x is the vertical
+
+                        lnP_plus = std::log(P(i+1,j,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i+1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus = std::log(eos_state.p);
+
+                        lnP_minus = std::log(P(i-1,j,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i-1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus = std::log(eos_state.p);
+
+                    } else if (ndims ==2 ) {
+                        // y is the vertical
+
+                        lnP_plus = std::log(P(i,j+1,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j+1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus = std::log(eos_state.p);
+
+                        lnP_minus = std::log(P(i,j-1,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j-1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus = std::log(eos_state.p);
+
+                    } else {
+                        // z is the vertical
+
+                        lnP_plus = std::log(P(i,j,k+1));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j,k+1,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus = std::log(eos_state.p);
+
+                        lnP_minus = std::log(P(i,j,k-1));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j,k-1,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus = std::log(eos_state.p);
                     }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_plus = std::log(eos_state.p);
+                } else{
+                    //spherical case
 
-                    lnP_minus = std::log(P(i-1,j,k));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i-1,j,k,n);
+                    if (ndims == 1) {
+                        // x is the vertical
+                        // same as plane-parallel
+
+                        lnP_plus = std::log(P(i+1,j,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i+1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus = std::log(eos_state.p);
+
+                        lnP_minus = std::log(P(i-1,j,k));
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i-1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus = std::log(eos_state.p);
+
+                    } else if (ndims ==2 ) {
+                        // r is made of x and y 
+
+                        // actual  
+                        lnP_plus = (xpos / dx[0]) * std::log(P(i+1,j,k))
+                                 + (ypos / dx[1]) * std::log(P(i,j+1,k));
+
+                        lnP_minus = (xpos / dx[0]) * std::log(P(i-1,j,k))
+                                  + (ypos / dx[1]) * std::log(P(i,j-1,k));
+
+                        //alternate
+                        //plus - x 
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i+1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (xpos / dx[0]) * std::log(eos_state.p);
+
+                        //plus - y
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j+1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (ypos / dx[1]) * std::log(eos_state.p);
+
+                        //minus - x 
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i-1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (xpos / dx[0]) * std::log(eos_state.p);
+
+                        //minus - y
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j-1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus += (ypos / dx[1]) * std::log(eos_state.p);
+
+                    } else {
+                        // r is made of x, y and z 
+
+                        // actual  
+                        lnP_plus = (xpos / dx[0]) * std::log(P(i+1,j,k))
+                                 + (ypos / dx[1]) * std::log(P(i,j+1,k))
+                                 + (zpos / dx[2]) * std::log(P(i,j,k+1));
+
+                        lnP_minus = (xpos / dx[0]) * std::log(P(i-1,j,k))
+                                  + (ypos / dx[1]) * std::log(P(i,j-1,k))
+                                  + (zpos / dx[2]) * std::log(P(i,j,k-1));
+
+                        //alternate
+                        //plus - x 
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i+1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (xpos / dx[0]) * std::log(eos_state.p);
+
+                        //plus - y
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j+1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (ypos / dx[1]) * std::log(eos_state.p);
+
+                        //plus - z
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j,k+1,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (zpos / dx[2]) * std::log(eos_state.p);
+
+                        //minus - x 
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i-1,j,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_plus += (xpos / dx[0]) * std::log(eos_state.p);
+
+                        //minus - y
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j-1,k,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus += (ypos / dx[1]) * std::log(eos_state.p);
+
+                        //minus - z
+                        for (int n = 0; n < NumSpec; ++n) {
+                            eos_state.xn[n] = X(i,j,k-1,n);
+                        }
+                        eos(eos_input_rt, eos_state);
+                        lnPalt_minus += (zpos / dx[2]) * std::log(eos_state.p);
                     }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_minus = std::log(eos_state.p);
-
-                } else if (ndims ==2 ) {
-                    // y is the vertical
-
-                    lnP_plus = std::log(P(i,j+1,k));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i,j+1,k,n);
-                    }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_plus = std::log(eos_state.p);
-
-                    lnP_minus = std::log(P(i,j-1,k));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i,j-1,k,n);
-                    }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_minus = std::log(eos_state.p);
-
-                } else {
-                    // z is the vertical
-
-                    lnP_plus = std::log(P(i,j,k+1));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i,j,k+1,n);
-                    }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_plus = std::log(eos_state.p);
-
-                    lnP_minus = std::log(P(i,j,k-1));
-                    for (int n = 0; n < NumSpec; ++n) {
-                        eos_state.xn[n] = X(i,j,k-1,n);
-                    }
-                    eos(eos_input_rt, eos_state);
-                    lnPalt_minus = std::log(eos_state.p);
                 }
-
 
                 // chi_T still has the old (correct) value for i,j,k
 


### PR DESCRIPTION
Add spherical geometry to the `convective_grad`. Can turn on in parameters with `spherical=true`. Calculate radial derivatives from x,y,z like so for $dT/dP$:

$$
\frac{dT}{dP} = \left( \frac{x}{\Delta x} \frac{dT}{dx} + \frac{y}{\Delta y} \frac{dT}{dy} + \frac{z}{\Delta z} \frac{dT}{dz}\right) \/ \left(\frac{x}{\Delta x} \frac{dP}{dx} + \frac{y}{\Delta y} \frac{dP}{dy} + \frac{z}{\Delta z} \frac{dP}{dz} \right)
$$

